### PR TITLE
Fix ISteamHTTP error by changing hook

### DIFF
--- a/lua/autorun/server/iris_init.lua
+++ b/lua/autorun/server/iris_init.lua
@@ -47,7 +47,7 @@ local function sendGroupsToIris()
 end
 
 hook.Add( "Think", "CFC_IrisInterface_BulkRankUpdate", function()
-    hook.Remove( "Think", "CFC_ClAddonLoader_LoadAddons" )
+    hook.Remove( "Think", "CFC_IrisInterface_BulkRankUpdate" )
     sendGroupsToIris()
 end )
 

--- a/lua/autorun/server/iris_init.lua
+++ b/lua/autorun/server/iris_init.lua
@@ -46,7 +46,10 @@ local function sendGroupsToIris()
     }, nil, logError )
 end
 
-hook.Add( "InitPostEntity", "CFC_IrisInterface_BulkRankUpdate", sendGroupsToIris )
+hook.Add( "Think", "CFC_IrisInterface_BulkRankUpdate", function()
+    hook.Remove( "Think", "CFC_ClAddonLoader_LoadAddons" )
+    sendGroupsToIris()
+end )
 
 hook.Add( "ULibUserGroupChange", "CFC_IrisInterface_UpdateRanks", function( steamid, allows, denies, newGroup, oldGroup )
     local steamid64 = util.SteamIDTo64( steamid )


### PR DESCRIPTION
Error:
```
[cfc_glua_iris_interface]` HTTP failed - ISteamHTTP isn't available!
  1. postJson - addons/cfc_glua_iris_interface/lua/autorun/server/iris_init.lua:18
   2. func - addons/cfc_glua_iris_interface/lua/autorun/server/iris_init.lua:42
    3. ExecuteTransaction - lua/includes/modules/sentry.lua:834
     4. unknown - lua/includes/modules/sentry.lua:1143
      5. xpcall - [C]:-1
       6. unknown - lua/includes/modules/sentry.lua:836
 ```